### PR TITLE
Use COPY instead of ADD in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM composer:1.7.2
 
-ADD composer_laravel.lock /php-app/composer.lock
-ADD Gemfile_rails.lock /ruby-app/Gemfile.lock
-ADD package-lock_react.json /node-app/package-lock.json
-ADD Pipfile.lock /python-app/Pipfile.lock
-ADD Cargo.lock /rust-app/Cargo.lock
+COPY composer_laravel.lock /php-app/composer.lock
+COPY Gemfile_rails.lock /ruby-app/Gemfile.lock
+COPY package-lock_react.json /node-app/package-lock.json
+COPY Pipfile.lock /python-app/Pipfile.lock
+COPY Cargo.lock /rust-app/Cargo.lock


### PR DESCRIPTION
Hello,

The use of COPY is preferred over ADD when additional functionalities of ADD are not being used (like spraying the contents of a tar in a folder).

Ref: https://docs.docker.com/engine/articles/dockerfile_best-practices/#add-or-copy

Thanks.