### PR TITLE
Add GitLab CI integration (w/ gitlab.com)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,30 @@
+variables:
+  DOCKER_HOST: tcp://docker:2375
+
+services:
+  - docker:stable-dind
+
+stages:
+  - build
+  - test
+
+include:
+  # Trivy integration with GitLab Container Scanning
+  - remote: "https://github.com/aquasecurity/trivy/raw/master/contrib/Trivy.gitlab-ci.yml"
+
+build:
+  image: docker:stable
+  stage: build
+  variables:
+    IMAGE: $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
+  script:
+    - docker info
+    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
+    - docker build -t $IMAGE .
+    - docker push $IMAGE
+
+# This overriding is not mandatory for GitLab Securty Scanning Report integration
+# and is mainly for a demonstration how it works on GitLab Community Edition
+Trivy_container_scanning:
+  artifacts:
+    paths: [gl-container-scanning-report.json]

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
   - docker build -t trivy-ci-test:${COMMIT} .
   - curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/install.sh | sudo sh -s -- -b /usr/local/bin
+
 script:
   - docker images
-  - trivy --exit-code 0 --severity HIGH --no-progress trivy-ci-test:${COMMIT}
-  - trivy --exit-code 1 --severity CRITICAL --no-progress trivy-ci-test:${COMMIT}
+  - trivy --exit-code 0 --severity CRITICAL --no-progress trivy-ci-test:${COMMIT}


### PR DESCRIPTION
Adds GitLab CI integration as live demo at gitlab.com.

Expecting to have https://gitlab.com/aquasecurity and https://gitlab.com/aquasecurity/trivy-ci-test mirroring from this repo, will add https://gitlab.com/aquasecurity/trivy-ci-test/pipelines

Blocked by aquasecurity/trivy#376

## TODO

- [x] Get aquasecurity/trivy#387 merged
- [x] Get aquasecurity/trivy#376 merged

## Results

- https://gitlab.com/tnir/trivy-ci-test/pipelines